### PR TITLE
Validate empty fields on Create Goal

### DIFF
--- a/api/goals_routes.js
+++ b/api/goals_routes.js
@@ -2,12 +2,13 @@ const router = require('express').Router();
 const db = require("./query_class.js");
 const ResponseData = require("./response.js");
 const findTable = require("./utilities/find_table.js");
-const validates = require("./utilities/validations.js");
+const Validations = require("./utilities/validations.js");
 //routes that serve the data base and return json
 
 
 router.post("/goals/create", (req, res) => {
   const r = new ResponseData();
+  let isValidCredentials = new Validations(req.body.data).check();
   //this route implies we are looking to insert into goals table
   if (req.xhr && req.session['user-id']) {
     console.log("REQ BODY", req.body);
@@ -121,6 +122,7 @@ router.post("/goals/:id/tasks/create", (req, res) => {
         is_done: false,
         goal_id: req.params.id
       };
+      let v = new Validations(query.data);
       db.insertRow(query, (err, data) => {
         if (err) {
           r.setErrorMsg("Your task didn't save i'm so sorry so sad oh noo");

--- a/api/goals_routes.js
+++ b/api/goals_routes.js
@@ -122,14 +122,19 @@ router.post("/goals/:id/tasks/create", (req, res) => {
         is_done: false,
         goal_id: req.params.id
       };
-      let v = new Validations(query.data);
-      db.insertRow(query, (err, data) => {
-        if (err) {
-          r.setErrorMsg("Your task didn't save i'm so sorry so sad oh noo");
-        } else {
-          data.length ? r.setData(data) : r.setErrorMsg("A different error message idk");
-        }
-      });
+      let v = new Validations(query.data).check();
+      //check tasks for validations
+      if(v) {
+        db.insertRow(query, (err, data) => {
+          if (err) {
+            r.setErrorMsg("Your task didn't save i'm so sorry so sad oh noo");
+          } else {
+            data.length ? r.setData(data) : r.setErrorMsg("A different error message idk");
+          }
+        });
+      } else {
+        r.setErrorMsg("Could not save your task, is it blank?");
+      }
     });
     res.send(r);
 

--- a/src/components/CreateGoalModal.jsx
+++ b/src/components/CreateGoalModal.jsx
@@ -12,6 +12,8 @@ class CreateGoalModal extends Component {
       goalName: "",
       private: true,
       tasks: [""],
+      goalNameErr: "",
+      taskNameErr: "",
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -19,6 +21,9 @@ class CreateGoalModal extends Component {
     this.renderForms = this.renderForms.bind(this);
     this.handleAddTask = this.handleAddTask.bind(this);
     this.updateTask = this.updateTask.bind(this);
+    this.validateFormInputs = this.validateFormInputs.bind(this);
+    this.renderErrors = this.renderErrors.bind(this);
+    this.submitToDatabase = this.submitToDatabase.bind(this);
   }
 
   handleChange(event) {
@@ -30,14 +35,17 @@ class CreateGoalModal extends Component {
 
  handleSubmit(event) {
   event.preventDefault();
+  this.validateFormInputs(this.submitToDatabase);
+  }
 
+  submitToDatabase(goal, tasks) {
     $.ajax({
       method: 'post',
       url: '/api/goals/create',
       dataType: 'json',
       data: {
         data: {
-          name: this.state.goalName,
+          name: goal,
           private: this.state.private,
         }
       }
@@ -48,12 +56,13 @@ class CreateGoalModal extends Component {
         dataType: 'json',
         data: {
           data: {
-            taskNames: this.state.tasks
+            taskNames: tasks,
           }
         }
       }).done ((data) => {
         this.setState({goalName: ""});
         this.setState({tasks: [""]});
+        this.setState({goalNameErr: ""});
         $("#create-goal-modal").modal("hide");
         this.props.updateGoalsIndex();
       });
@@ -80,7 +89,33 @@ class CreateGoalModal extends Component {
     console.log("IM A COOL TASK")
   }
 
+  validateFormInputs(cb) {
+    console.log("SUP WITH THE STATE", this.state.tasks)
+    if (this.state.goalName === "") {
+      this.setState({goalNameErr: "Goal Name can't be blank, Frank!"});
+    }
+    let tasks = this.state.tasks;
+    let cleanTasks = tasks.filter(Boolean);
+    console.log("CLEAN ME UP BUTTERCUP", cleanTasks)
+    if (this.state.goalNameErr === "") {
+      cb(this.state.goalName, cleanTasks);
+    }
+  }
+
+  renderErrors() {
+    if (this.state.goalNameErr !== "") {
+      return (
+        <div className="alert alert-warning">
+          {this.state.goalNameErr}
+        </div>
+      )
+    }
+    // this.setState({goalNameErr: ""});
+  }
+
+
   render() {
+    console.log("WHERE MY GOAAAAAL NAAAAME ERRRRR  MESSAGE AT", this.state.goalNameErr)
 
     return (
       <div className="modal fade" id="create-goal-modal" tabIndex="-1" role="dialog" aria-labelledby="myModalLabel">
@@ -93,6 +128,7 @@ class CreateGoalModal extends Component {
             </div>
 
             <div id="create-goal-body" className="modal-body">
+            {this.renderErrors()}
             <form className="form-horizontal" onSubmit={this.handleSubmit}>
 
               <div className="form-group">
@@ -104,7 +140,7 @@ class CreateGoalModal extends Component {
               {this.renderForms()}
               </div>
 
-              <button type="button" class="btn btn-default btn-lg" name="add-task" data-toggle="popover" onClick={this.handleAddTask}>
+              <button type="button" className="btn btn-default btn-lg" name="add-task" data-toggle="popover" onClick={this.handleAddTask}>
                 <span className="glyphicon glyphicon-plus" aria-hidden="true"></span>
               </button>
 

--- a/src/components/CreateGoalModal.jsx
+++ b/src/components/CreateGoalModal.jsx
@@ -35,7 +35,8 @@ class CreateGoalModal extends Component {
 
  handleSubmit(event) {
   event.preventDefault();
-  this.validateFormInputs(this.submitToDatabase);
+  let goalName = this.state.goalName.trim();
+  this.validateFormInputs(goalName, this.submitToDatabase);
   }
 
   submitToDatabase(goal, tasks) {
@@ -63,6 +64,7 @@ class CreateGoalModal extends Component {
         this.setState({goalName: ""});
         this.setState({tasks: [""]});
         this.setState({goalNameErr: ""});
+
         $("#create-goal-modal").modal("hide");
         this.props.updateGoalsIndex();
       });
@@ -89,16 +91,14 @@ class CreateGoalModal extends Component {
     console.log("IM A COOL TASK")
   }
 
-  validateFormInputs(cb) {
-    console.log("SUP WITH THE STATE", this.state.tasks)
-    if (this.state.goalName === "") {
-      this.setState({goalNameErr: "Goal Name can't be blank, Frank!"});
-    }
+  validateFormInputs(goalName, cb) {
     let tasks = this.state.tasks;
     let cleanTasks = tasks.filter(Boolean);
-    console.log("CLEAN ME UP BUTTERCUP", cleanTasks)
-    if (this.state.goalNameErr === "") {
-      cb(this.state.goalName, cleanTasks);
+    if (goalName === "") {
+      this.setState({goalNameErr: "Goal Name can't be blank, Frank!"});
+    }
+    if (goalName.length) {
+      cb(goalName, cleanTasks);
     }
   }
 

--- a/src/components/CreateGoalModal.jsx
+++ b/src/components/CreateGoalModal.jsx
@@ -93,13 +93,19 @@ class CreateGoalModal extends Component {
 
   validateFormInputs(goalName, cb) {
     let tasks = this.state.tasks;
-    let cleanTasks = tasks.filter(Boolean);
+
+    let cleanTasks = tasks.map((elm) => {
+      return elm.trim();
+    })
+    cleanTasks = cleanTasks.filter(Boolean);
+
     if (goalName === "") {
       this.setState({goalNameErr: "Goal Name can't be blank, Frank!"});
     }
-    if (goalName.length) {
+    if (goalName.length && cleanTasks.length) {
       cb(goalName, cleanTasks);
     }
+
   }
 
   renderErrors() {

--- a/src/components/CreateGoalModal.jsx
+++ b/src/components/CreateGoalModal.jsx
@@ -16,14 +16,14 @@ class CreateGoalModal extends Component {
       taskNameErr: "",
     };
 
+    this.handleAddTask = this.handleAddTask.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.renderForms = this.renderForms.bind(this);
-    this.handleAddTask = this.handleAddTask.bind(this);
-    this.updateTask = this.updateTask.bind(this);
-    this.validateFormInputs = this.validateFormInputs.bind(this);
     this.renderErrors = this.renderErrors.bind(this);
+    this.renderForms = this.renderForms.bind(this);
     this.submitToDatabase = this.submitToDatabase.bind(this);
+    this.validateFormInputs = this.validateFormInputs.bind(this);
+    this.updateTask = this.updateTask.bind(this);
   }
 
   handleChange(event) {
@@ -36,6 +36,8 @@ class CreateGoalModal extends Component {
  handleSubmit(event) {
   event.preventDefault();
   let goalName = this.state.goalName.trim();
+  this.setState({goalNameErr: ""});
+  this.setState({taskNameErr: ""});
   this.validateFormInputs(goalName, this.submitToDatabase);
   }
 
@@ -63,10 +65,8 @@ class CreateGoalModal extends Component {
       }).done ((data) => {
         this.setState({goalName: ""});
         this.setState({tasks: [""]});
-        this.setState({goalNameErr: ""});
-
-        $("#create-goal-modal").modal("hide");
         this.props.updateGoalsIndex();
+        $("#create-goal-modal").modal("hide");
       });
     });
   }
@@ -88,24 +88,23 @@ class CreateGoalModal extends Component {
     let tasks = this.state.tasks;
     tasks.push("");
     this.setState({tasks: tasks});
-    console.log("IM A COOL TASK")
   }
 
   validateFormInputs(goalName, cb) {
     let tasks = this.state.tasks;
-
     let cleanTasks = tasks.map((elm) => {
       return elm.trim();
-    })
+    });
     cleanTasks = cleanTasks.filter(Boolean);
-
     if (goalName === "") {
       this.setState({goalNameErr: "Goal Name can't be blank, Frank!"});
-    }
+    };
+    if (cleanTasks.length < 1 ) {
+      this.setState({taskNameErr: "Tasks can't be clean, Maureen!"});
+    };
     if (goalName.length && cleanTasks.length) {
       cb(goalName, cleanTasks);
-    }
-
+    };
   }
 
   renderErrors() {
@@ -115,13 +114,17 @@ class CreateGoalModal extends Component {
           {this.state.goalNameErr}
         </div>
       )
+    } else if (this.state.taskNameErr !== "") {
+      return (
+        <div className="alert alert-warning">
+          {this.state.taskNameErr}
+        </div>
+      );
     }
-    // this.setState({goalNameErr: ""});
   }
 
 
   render() {
-    console.log("WHERE MY GOAAAAAL NAAAAME ERRRRR  MESSAGE AT", this.state.goalNameErr)
 
     return (
       <div className="modal fade" id="create-goal-modal" tabIndex="-1" role="dialog" aria-labelledby="myModalLabel">
@@ -156,7 +159,6 @@ class CreateGoalModal extends Component {
 
             </form>
             </div>
-
           </div>
         </div>
       </div>


### PR DESCRIPTION
Users receive an instructional error message when leaving a blank field in their Goal name or Task name. Form does not send empty fields to database, and trims whitespace in fields. Validations on goal_route server-side.