### PR TITLE
fix progress bar bug

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -56,7 +56,6 @@ class App extends Component {
       url: "/login",
       dataType: 'json'
     }).done((data) => {
-      // console.log("Am I logged in?:", data);
       this.setState({isLoggedIn: data.isLoggedIn, name: data.name});
       this.updateFromDatabase();
     });
@@ -80,8 +79,6 @@ class App extends Component {
   }
 
   render() {
-    // console.log('==================Goals: ', this.state.goals, ' ============================');
-
     console.log("Rendering <App/>");
     return (
       <div id="wrapper">

--- a/src/components/CreateGoalModal.jsx
+++ b/src/components/CreateGoalModal.jsx
@@ -78,7 +78,6 @@ class CreateGoalModal extends Component {
       }).done ((data) => {
         this.setState({goalName: ""});
         this.setState({tasks: [""]});
-        console.log("Created a goal, sending to app for a db update!");
         this.props.updateGoalsIndex();
         $("#create-goal-modal").modal("hide");
       });

--- a/src/components/Goals.jsx
+++ b/src/components/Goals.jsx
@@ -20,7 +20,6 @@ class Goals extends Component {
         <h3> Loading Goals... </h3>
       );
     } else if (this.props.goalList.length === 0) {
-      // console.log("in else if statement of goals.jsx");
       return (
         <div>
           <h3> You haven't created any goals yet!</h3>

--- a/src/components/ProgressBar.jsx
+++ b/src/components/ProgressBar.jsx
@@ -6,17 +6,9 @@ class ProgressBar extends Component {
     this.calculateProgress = this.calculateProgress.bind(this);
   }
 
-  componentWillMount() {
-    this.calculateProgress();
-  }
-
-  // componentWillUpdate() {
-  //   this.calculateProgress();
-  // }
   calculateProgress () {
     // console.log("===============================TaskArray in ProgressBar is", this.props.taskArray);
     let tasks = this.props.taskArray;
-    console.log("Calculating progress of", tasks[0].name + "===================================")
     let finishedTasks = 0;
     for (let i = 0; i < tasks.length; i++){
       if (tasks[i].is_done === true) {

--- a/src/components/SingleGoal.jsx
+++ b/src/components/SingleGoal.jsx
@@ -55,7 +55,6 @@ class SingleGoal extends Component {
           }
         }
       }).then(() => {
-        console.log("Post request finished, sending update to app");
         setTimeout(() => {
           this.props.update();
         }, 200);
@@ -144,7 +143,7 @@ class SingleGoal extends Component {
   render() {
     return (
       <div>
-       {this.renderGoals()}
+        {this.renderGoals()}
       </div>
     );
   }

--- a/styles/_goals.scss
+++ b/styles/_goals.scss
@@ -30,7 +30,14 @@
     margin: auto;
     position: absolute;
     top: 54px; left: 0; bottom: 0; right: 0;
+
+    .progress-bar {
+      -webkit-transition: none;
+      -o-transition: none;
+      transition: none;
+    }
   }
+
 
   .strikethrough {
     position: relative;
@@ -53,7 +60,7 @@
   transition: max-height 1s ease-in;
   // background: #e5feff;
   overflow: hidden;
-  // "height: 0" not work with css transitions
+  // "height: 0" not working with css transitions
   max-height: 800px;
 }
 


### PR DESCRIPTION
The issue was in bootstrap's transition timer affecting the render stages of progress bars that should have been unaffected. I overrode the transition class so now the progress bar doesn't glitch. However, the progress bar doesn't have its nice slide-y look anymore when it updates so if we have time it would be nice to go back and write some logic that could maybe help with that. 